### PR TITLE
feat: Pre-load default GPX and add cut-off validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,6 @@
 <body>
   <h1>EnduroSync GPX Pace Planner</h1>
 
-  <div>
-    <label for="gpxFile">Upload GPX File:</label>
-    <input type="file" id="gpxFile" accept=".gpx">
-  </div>
 
   <div id="courseInfo"></div>
 

--- a/style.css
+++ b/style.css
@@ -1,0 +1,9 @@
+.cut-off-row {
+  background-color: #f0f0f0;
+  font-weight: bold;
+}
+
+.cut-off-row td {
+  border-top: 2px solid #333;
+  border-bottom: 2px solid #333;
+}


### PR DESCRIPTION
This commit introduces several new features to the pacing planner:

- The `nuts300.gpx` file is now pre-loaded by default, removing the need for manual file upload. The file upload UI has been removed.
- Race cut-off points for Kalmakaltio, Hetta, and Pallas, as well as the final finish time, have been added.
- The application now validates your goal time against these cut-offs, ensuring a 3-hour buffer is maintained at each checkpoint. An alert is shown if the validation fails.
- The cut-off points are now displayed directly in the pacing plan table for easy reference.