### PR TITLE
feat: Display energy requirement as Carbs g/h

### DIFF
--- a/main.js
+++ b/main.js
@@ -117,7 +117,7 @@ function calculateEnergyPlan(sections) {
                 <tr>
                     <th>Section</th>
                     <th>Avg. Pace (min/km)</th>
-                    <th>Calories/hour</th>
+                    <th>Carbs g/h</th>
                     <th>Total Section Calories</th>
                 </tr>
             </thead>
@@ -132,7 +132,7 @@ function calculateEnergyPlan(sections) {
             <tr>
                 <td>${section.name}</td>
                 <td>${avgPace.toFixed(2)}</td>
-                <td>${Math.round(section.caloriesPerHour)}</td>
+                <td>${Math.round(section.caloriesPerHour / 4)}</td>
                 <td>${Math.round(section.totalCalories)}</td>
             </tr>
         `;


### PR DESCRIPTION
This commit adjusts the display of the energy plan based on your feedback to make it more actionable for nutrition planning.

- The "Calories/hour" column in the energy plan table has been renamed to "Carbs g/h".
- The value in this column is now calculated by taking the total calories per hour and dividing by 4, approximating the conversion from calories to grams of carbohydrates.